### PR TITLE
Update versions: backend 1.3.0 and client 2.0.0

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -57,7 +57,7 @@ services:
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
     command: ["start", "--proxy-headers", "xforwarded", "--http-enabled", "true"]
   mde-backend:
-    image: ghcr.io/gdi-be/mde-backend:1.1.3
+    image: ghcr.io/gdi-be/mde-backend:1.3.0
     container_name: mde-backend
     hostname: mde-backend
     restart: unless-stopped
@@ -79,7 +79,7 @@ services:
       - ./codelists:/data/codelists:U
     privileged: true
   mde-client:
-    image: ghcr.io/gdi-be/mde-client:1.1.10
+    image: ghcr.io/gdi-be/mde-client:2.0.0
     container_name: mde-client
     hostname: mde-client
     restart: unless-stopped

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -57,7 +57,7 @@ services:
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
     command: ["start", "--proxy-headers", "xforwarded", "--http-enabled", "true"]
   mde-backend:
-    image: ghcr.io/gdi-be/mde-backend:1.1.3
+    image: ghcr.io/gdi-be/mde-backend:1.3.0
     container_name: mde-backend
     hostname: mde-backend
     restart: unless-stopped
@@ -79,7 +79,7 @@ services:
       - ./codelists:/data/codelists:U
     privileged: true
   mde-client:
-    image: ghcr.io/gdi-be/mde-client:1.1.10
+    image: ghcr.io/gdi-be/mde-client:2.0.0
     container_name: mde-client
     hostname: mde-client
     restart: unless-stopped


### PR DESCRIPTION
This pull request includes updates to the `docker-compose-prod.yml` and `docker-compose-test.yml` files to upgrade the images for `mde-backend` and `mde-client` services.

Image updates:

* [`docker-compose-prod.yml`](diffhunk://#diff-0faee0a2e11c359bfbe8424e6a5c5a0d58881176f85af37e273497e0dad42840L60-R60): Updated `mde-backend` image from `1.1.3` to `1.3.0`
* [`docker-compose-prod.yml`](diffhunk://#diff-0faee0a2e11c359bfbe8424e6a5c5a0d58881176f85af37e273497e0dad42840L82-R82): Updated `mde-client` image from `1.1.10` to `2.0.0`
* [`docker-compose-test.yml`](diffhunk://#diff-6e72fc85bdf9d7aa207102402a2de7cf7aec4109d2378b66921a5c70d07a4f1fL60-R60): Updated `mde-backend` image from `1.1.3` to `1.3.0`
* [`docker-compose-test.yml`](diffhunk://#diff-6e72fc85bdf9d7aa207102402a2de7cf7aec4109d2378b66921a5c70d07a4f1fL82-R82): Updated `mde-client` image from `1.1.10` to `2.0.0`