### PR TITLE
Update versions, mde-backend v5.2.1, mde-client v6.4.1

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -111,7 +111,7 @@ services:
     volumes:
       - ./esdata-public:/usr/share/elasticsearch/data:z
   mde-backend:
-    image: ghcr.io/gdi-be/mde-backend:5.0.5
+    image: ghcr.io/gdi-be/mde-backend:5.2.1
     container_name: mde-backend
     hostname: mde-backend
     restart: always
@@ -130,6 +130,9 @@ services:
       CSW_PASSWORD: ${CSW_PASSWORD}
       CODELISTS_DIR: ${CODELISTS_DIR}
       JAVA_TOOL_OPTIONS: "-Dlog4j2.configurationFile=/config/log4j2.properties"
+      CLEANUP_USERS_ENABLED: false
+      CLEANUP_USERS_CRON: "0 0 0 ? * MON-FRI" # Every weekday at midnight
+
     volumes:
       - ./mde-backend/lucene:/lucene
       - ./mde-backend/keystore/cacerts:/opt/java/openjdk/lib/security/cacerts:U
@@ -138,7 +141,7 @@ services:
       - ./codelists:/data/codelists:U
     privileged: true
   mde-client:
-    image: ghcr.io/gdi-be/mde-client:6.1.12
+    image: ghcr.io/gdi-be/mde-client:6.4.1
     container_name: mde-client
     hostname: mde-client
     restart: always


### PR DESCRIPTION
This PR updates the backend and client versions.

Additionally, a config is added to docker-compose, related to automatic cleanup of user references:

The backend can remove outdated references to users who no longer exist in Keycloak from metadata records. This process is configured via the environment variables of the backend container:

```yaml
CLEANUP_USERS_ENABLED: false
CLEANUP_USERS_CRON: "0 0 0 ? * MON-FRI"
```

- `CLEANUP_USERS_ENABLED` enables (`true`) or disables (`false`) automatic cleanup.
- `CLEANUP_USERS_CRON` specifies the execution time as a cron expression. The example runs the cleanup Monday through Friday at midnight.

If `CLEANUP_USERS_ENABLED: false`, the cleanup is not performed. A simultaneously set value for `CLEANUP_USERS_CRON` does not enable it. Changes to the configuration take effect after a restart of the backend container (e.g. `podman compose -f docker-compose-test.yml restart mde-backend`).